### PR TITLE
Fixed merging service.resources

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 100,
+  "semi": false,
+  "trailingComma": "es5"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-import-config-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-import-config-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Adds possibility to import YAML files in serverless.yaml config file",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,4 +1,4 @@
-import { isObject } from './utils'
+import { isObject } from "./utils"
 
 const merge = (target: any, source: any): object => {
   if (source == null) {
@@ -14,7 +14,7 @@ const merge = (target: any, source: any): object => {
     if (isObject(value) && isObject(target[key])) {
       // merge deeply
       target[key] = merge(target[key], value)
-    } else if (!(key in target)) {
+    } else if (target[key] === undefined) {
       // set new value but do not override
       target[key] = value
     }


### PR DESCRIPTION
By default serverless fills `service.resources` with `undefined` when there are no `resources` in the initial `serverless.yaml` file.
This fix allows overriding fields with `undefined` value.